### PR TITLE
cbor & json: add HeaderPath variable

### DIFF
--- a/cbor/cbor.go
+++ b/cbor/cbor.go
@@ -8,10 +8,12 @@ import (
 	mc "github.com/jbenet/go-multicodec"
 )
 
+var HeaderPath string
 var Header []byte
 
 func init() {
-	Header = mc.Header([]byte("/cbor"))
+	HeaderPath = "/cbor"
+	Header = mc.Header([]byte(HeaderPath))
 }
 
 type codec struct {

--- a/json/json.go
+++ b/json/json.go
@@ -10,12 +10,16 @@ import (
 	mc "github.com/jbenet/go-multicodec"
 )
 
+var HeaderPath string
 var Header []byte
+var HeaderMsgioPath string
 var HeaderMsgio []byte
 
 func init() {
-	Header = mc.Header([]byte("/json"))
-	HeaderMsgio = mc.Header([]byte("/json/msgio"))
+	HeaderPath = "/json"
+	HeaderMsgioPath = "/json/msgio"
+	Header = mc.Header([]byte(HeaderPath))
+	HeaderMsgio = mc.Header([]byte(HeaderMsgioPath))
 }
 
 type codec struct {


### PR DESCRIPTION
In order to be able to compare on the decoded multicodec header path, it is convenient to have that path as a public variable for json and cbor.